### PR TITLE
fix typo and replace cocker as it is getting 404 from dog api

### DIFF
--- a/src/breeds.js
+++ b/src/breeds.js
@@ -3,5 +3,6 @@ export const breeds = [
   'affenpinscher',
   'australian',
   'mexicanhairless',
-  'cocker',
+  'doberman',
+  'chihuahua'
 ]

--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ function dogCardMaker({ imageURL, breed }) {
 
 // 👉 TASK 4- Bring the Axios library into the project using one of two methods:
 //    * Traditional way: put another script tag inside index.html (`https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js`)
-//    * Proyects with npm: install it with npm and import it into this file
+//    * Projects with npm: install it with npm and import it into this file
 
 
 // 👉 TASK 5- Fetch dogs from `https://dog.ceo/api/breed/{breed}/images/random/{number}`


### PR DESCRIPTION
Currently if you make a request to https://dog.ceo/api/breed/cocker/images/random, you get back a 404:
```
$ curl -s https://dog.ceo/api/breed/cocker/images/random | jq .
{
  "status": "error",
  "message": "Breed not found (master breed does not exist)",
  "code": 404
}
```